### PR TITLE
Iterate over java opts

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -94,7 +94,7 @@ Information about Zeebe you can find [here](https://docs.camunda.io/docs/compone
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` | 
 | | `logLevel` | Defines the log level which is used by the Zeebe brokers; must be one of: ERROR, WARN, INFO, DEBUG, TRACE | `info` |
 | | `log4j2` | Can be used to overwrite the Log4J 2.x XML configuration. If provided, the contents given will be written to file and will overwrite the distribution's default `/usr/local/zeebe/config/log4j2.xml` | `` |
-| | `JavaOpts` | Can be used to set the Zeebe Broker JavaOpts. This is where you should configure the jvm heap size. | `-XX:MaxRAMPercentage=25.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError` |
+| | `JavaOpts` | Can be used to set the Zeebe Broker JavaOpts. This is where you should configure the jvm heap size. | `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError` |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.httpPort` | Defines the port of the HTTP endpoint, where for example metrics are provided | `9600` |
 | | `service.httpName` | Defines the name of the HTTP endpoint, where for example metrics are provided | `http` |

--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -146,6 +146,7 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `podLabels` | Can be used to define extra gateway pod labels | `{ }` |
 | | `logLevel` | Defines the log level which is used by the gateway | `info` |
 | | `log4j2` | Can be used to overwrite the log4j2 configuration of the gateway | `""` |
+| | `JavaOpts` | Can be used to set the Zeebe Gateway JavaOpts. This is where you should configure the jvm heap size. | `-XX:+ExitOnOutOfMemoryError` |
 | | `env` | Can be used to set extra environment variables in each gateway container | `[ ]` |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |
 | | `containerSecurityContext` | Defines the security options the gateway container should be run with | `{ } `|

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-deployment.golden.yaml
@@ -61,7 +61,7 @@ spec:
             - name: ZEEBE_LOG_LEVEL
               value: "info"
             - name: JAVA_TOOL_OPTIONS
-              value: 
+              value: "-XX:+ExitOnOutOfMemoryError"
             - name: ZEEBE_GATEWAY_CLUSTER_CONTACTPOINT
               value: ccsm-helm-test-zeebe:26502
             - name: ZEEBE_GATEWAY_NETWORK_HOST

--- a/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe/golden/statefulset.golden.yaml
@@ -96,7 +96,7 @@ spec:
             fieldRef:
               fieldPath: metadata.name
         - name: JAVA_TOOL_OPTIONS
-          value: "-XX:MaxRAMPercentage=25.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError"
+          value: "-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/usr/local/zeebe/data -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log -XX:+ExitOnOutOfMemoryError"
         - name: ZEEBE_BROKER_DATA_SNAPSHOTPERIOD
           value: 5m
         - name: ZEEBE_BROKER_DATA_DISKUSAGECOMMANDWATERMARK

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -207,6 +207,9 @@ zeebe-gateway:
   logLevel: info
   # Log4j2 can be used to overwrite the log4j2 configuration of the gateway
   log4j2: ''
+  # JavaOpts can be used to set java options for the zeebe gateways
+  javaOpts: >-
+    -XX:+ExitOnOutOfMemoryError
 
   # Env can be used to set extra environment variables in each gateway container
   env: [ ]

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -94,7 +94,6 @@ zeebe:
   log4j2: ''
   # JavaOpts can be used to set java options for the zeebe brokers
   javaOpts: >-
-    -XX:MaxRAMPercentage=25.0
     -XX:+HeapDumpOnOutOfMemoryError
     -XX:HeapDumpPath=/usr/local/zeebe/data
     -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log


### PR DESCRIPTION

* Per default the java max ram percentage is set to the same value, so we removed the max ram percentage
* In order to make sure that the gateway exits on out of memory, we set related java option and add documentation around the javaOpts variable

closes https://github.com/camunda/camunda-cloud-helm/issues/155