### PR TITLE
IT test enhancement

### DIFF
--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -94,13 +94,13 @@ func (s *integrationTest) TestServicesEnd2End() {
 
 func (s *integrationTest) assertProcessDefinitionFromOperate() {
 	message := retry.DoWithRetry(s.T(),
-		"query and assert process definition from operate",
+		"Try to query and assert process definition from operate",
 		10,
 		10*time.Second,
 		func() (string, error) {
 			responseBuf, err := s.queryProcessDefinitionsFromOperate()
 			if err != nil {
-				return "", nil
+				return "", err
 			}
 
 			jsonString := responseBuf.String()
@@ -108,7 +108,7 @@ func (s *integrationTest) assertProcessDefinitionFromOperate() {
 			var objectMap map[string]interface{}
 			err = json.Unmarshal(responseBuf.Bytes(), &objectMap)
 			if err != nil {
-				return "", nil
+				return "", err
 			}
 
 			total := objectMap["total"].(float64)
@@ -132,7 +132,7 @@ func (s *integrationTest) createProcessInstance() {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 
-	message := retry.DoWithRetry(s.T(), "Create Process instance", 10, 1*time.Second, func() (string, error) {
+	message := retry.DoWithRetry(s.T(), "Try to create Process instance", 10, 1*time.Second, func() (string, error) {
 		_, err = client.NewCreateInstanceCommand().ProcessDefinitionKey(deployProcessResponse.Processes[0].ProcessDefinitionKey).Send(ctx)
 		return "Process instance created.", err
 	})
@@ -210,9 +210,6 @@ func (s *integrationTest) awaitElasticPods() {
 	for _, pod := range pods {
 		k8s.WaitUntilPodAvailable(s.T(), s.kubeOptions, pod.Name, 10, 10*time.Second)
 	}
-	// we need some more time for operate to become healthy / ready
-	// todo introduce operate readiness check
-	time.Sleep(30 * time.Second)
 }
 
 func (s *integrationTest) deployProcess(err error, client zbc.Client) *pb.DeployProcessResponse {

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -90,6 +90,10 @@ func (s *integrationTest) TestGatewayConnection() {
 	s.Require().NoError(err, "failed to create Zeebe client")
 	defer closeFn()
 
+	s.assertGatewayTopology(err, client)
+}
+
+func (s *integrationTest) assertGatewayTopology(err error, client zbc.Client) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 	topology, err := client.NewTopologyCommand().Send(ctx)

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -12,12 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build integration
 // +build integration
 
 package integration
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/cookiejar"
 	"os"
 	"path/filepath"
 	"strings"
@@ -80,12 +85,25 @@ func (s *integrationTest) TestServicesEnd2End() {
 	helm.Install(s.T(), options, s.chartPath, s.release)
 
 	// then
-	pods := k8s.ListPods(s.T(), s.kubeOptions, v1.ListOptions{LabelSelector: "app=camunda-cloud-self-managed"})
+	s.awaitCCSMPods()
+	closeFn, err := s.createProcessInstance()
 
-	for _, pod := range pods {
-		k8s.WaitUntilPodAvailable(s.T(), s.kubeOptions, pod.Name, 10, time.Duration(10 * time.Second))
-	}
+	s.awaitElasticPods()
+	responseBuf := s.queryProcessDefinitionsFromOperate(closeFn)
 
+	jsonString := responseBuf.String()
+	s.T().Logf("Request successful, got as response '%s'", jsonString)
+	var objectMap map[string]interface{}
+	err = json.Unmarshal(responseBuf.Bytes(), &objectMap)
+	s.Require().NoError(err)
+
+	total := objectMap["total"].(float64)
+	s.Require().GreaterOrEqual(total, float64(1))
+
+	s.Require().Contains(jsonString, "it-test-process")
+}
+
+func (s *integrationTest) createProcessInstance() (func(), error) {
 	serviceName := fmt.Sprintf("%s-zeebe-gateway", s.release)
 	client, closeFn, err := s.createPortForwardedClient(serviceName)
 	s.Require().NoError(err, "failed to create Zeebe client")
@@ -94,17 +112,68 @@ func (s *integrationTest) TestServicesEnd2End() {
 	s.assertGatewayTopology(err, client)
 	deployProcessResponse := s.deployProcess(err, client)
 	time.Sleep(10 * time.Second) // make sure that the deployment is distributed to all partitions
-	s.createProcessInstance(err, client, deployProcessResponse)
-}
-
-func (s *integrationTest) createProcessInstance(err error, client zbc.Client, deployProcessResponse *pb.DeployProcessResponse) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 	_, err = client.NewCreateInstanceCommand().ProcessDefinitionKey(deployProcessResponse.Processes[0].ProcessDefinitionKey).Send(ctx)
 	s.Require().NoError(err)
+	return closeFn, err
 }
 
-func (s *integrationTest) deployProcess(err error, client zbc.Client) (*pb.DeployProcessResponse) {
+func (s *integrationTest) queryProcessDefinitionsFromOperate(closeFn func()) *bytes.Buffer {
+	operateServiceName := fmt.Sprintf("%s-operate", s.release)
+	endpoint, closeFn := s.createPortForwardedHttpClient(operateServiceName)
+	defer closeFn()
+
+	jar, err := cookiejar.New(nil)
+	s.Require().NoError(err, "Error on creating cookie jar")
+
+	httpClient := http.Client{
+		Jar:     jar,
+		Timeout: 30 * time.Second,
+	}
+
+	// curl --include --request POST --cookie-jar "ope-session" "http://localhost:8080/api/login?username=demo&password=demo"
+	request, err := http.NewRequest("POST", "http://"+endpoint+"/api/login?username=demo&password=demo", nil)
+	s.Require().NoError(err)
+	request.Close = true
+
+	_, err = httpClient.Do(request)
+	s.Require().NoError(err)
+
+	// curl -i -H "Content-Type: application/json" -XPOST "http://localhost:8080/v1/process-definitions/list" --cookie "ope-session" -d "{}"
+	response, err := httpClient.Post("http://"+endpoint+"/v1/process-definitions/list", "application/json", bytes.NewBufferString("{}"))
+	s.Require().NoError(err)
+	s.Require().Equal(200, response.StatusCode)
+
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(response.Body)
+	s.Require().NoError(err)
+	defer response.Body.Close()
+	return buf
+}
+
+func (s *integrationTest) awaitCCSMPods() {
+	// await that all ccsm related pods become ready
+	pods := k8s.ListPods(s.T(), s.kubeOptions, v1.ListOptions{LabelSelector: "app=camunda-cloud-self-managed"})
+
+	for _, pod := range pods {
+		k8s.WaitUntilPodAvailable(s.T(), s.kubeOptions, pod.Name, 10, 10*time.Second)
+	}
+}
+
+func (s *integrationTest) awaitElasticPods() {
+	// await that all elastic related pods become ready, otherwise operate and tasklist can't answer requests
+	pods := k8s.ListPods(s.T(), s.kubeOptions, v1.ListOptions{LabelSelector: "app=elasticsearch-master"})
+
+	for _, pod := range pods {
+		k8s.WaitUntilPodAvailable(s.T(), s.kubeOptions, pod.Name, 10, 10*time.Second)
+	}
+	// we need some more time for operate to become healthy / ready
+	// todo introduce operate readiness check
+	time.Sleep(30 * time.Second)
+}
+
+func (s *integrationTest) deployProcess(err error, client zbc.Client) *pb.DeployProcessResponse {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelFn()
 	deployProcessResponse, err := client.NewDeployProcessCommand().AddResourceFile("it-test-process.bpmn").Send(ctx)
@@ -122,7 +191,6 @@ func (s *integrationTest) assertGatewayTopology(err error, client zbc.Client) {
 	s.Require().EqualValues(3, topology.ClusterSize)
 	s.Require().EqualValues(3, topology.PartitionsCount)
 	s.Require().EqualValues(3, topology.ReplicationFactor)
-	s.Require().EqualValues(3, len(topology.Brokers))
 }
 
 func (s *integrationTest) createPortForwardedClient(serviceName string) (zbc.Client, func(), error) {
@@ -147,6 +215,24 @@ func (s *integrationTest) createPortForwardedClient(serviceName string) (zbc.Cli
 	}
 
 	return client, func() { client.Close(); tunnel.Close() }, nil
+}
+
+func (s *integrationTest) createPortForwardedHttpClient(serviceName string) (string, func()) {
+	// NOTE: this only waits until the service is created, not until the underlying pods are ready to receive traffic
+	k8s.WaitUntilServiceAvailable(s.T(), s.kubeOptions, serviceName, 90, 1*time.Second)
+
+	// port forward the service to avoid having to set up a public endpoint that the test can access externally
+	localPort := k8s.GetAvailablePort(s.T())
+	// remote port needs to be container port - not service port!
+	tunnel := k8s.NewTunnel(s.kubeOptions, k8s.ResourceTypeService, serviceName, localPort, 8080)
+
+	// the gateway is not ready/receiving traffic until at least one leader is present
+	s.waitUntilPortForwarded(tunnel, 30, 2*time.Second)
+
+	endpoint := fmt.Sprintf("localhost:%d", localPort)
+	return endpoint, func() {
+		tunnel.Close()
+	}
 }
 
 func (s *integrationTest) waitUntilPortForwarded(tunnel *k8s.Tunnel, retries int, sleepBetweenRetries time.Duration) {

--- a/charts/ccsm-helm/test/integration/integration_test.go
+++ b/charts/ccsm-helm/test/integration/integration_test.go
@@ -70,7 +70,7 @@ func (s *integrationTest) TearDownTest() {
 	k8s.DeleteNamespace(s.T(), s.kubeOptions, s.namespace)
 }
 
-func (s *integrationTest) TestGatewayConnection() {
+func (s *integrationTest) TestServicesEnd2End() {
 	// given
 	options := &helm.Options{
 		KubectlOptions: s.kubeOptions,

--- a/charts/ccsm-helm/test/integration/it-test-process.bpmn
+++ b/charts/ccsm-helm/test/integration/it-test-process.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_07hpxev" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="Process_1ckbgzw" isExecutable="true">
+  <bpmn:process id="it-test-process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1kvyr8k</bpmn:outgoing>
     </bpmn:startEvent>

--- a/charts/ccsm-helm/test/integration/it-test-process.bpmn
+++ b/charts/ccsm-helm/test/integration/it-test-process.bpmn
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_07hpxev" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="Process_1ckbgzw" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1kvyr8k</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1kvyr8k" sourceRef="StartEvent_1" targetRef="Activity_0cyfv6p" />
+    <bpmn:userTask id="Activity_0cyfv6p" name="It Test">
+      <bpmn:incoming>Flow_1kvyr8k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1f3rst9</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_02xj7ay">
+      <bpmn:incoming>Flow_1f3rst9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1f3rst9" sourceRef="Activity_0cyfv6p" targetRef="Event_02xj7ay" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1ckbgzw">
+      <bpmndi:BPMNEdge id="Flow_1kvyr8k_di" bpmnElement="Flow_1kvyr8k">
+        <di:waypoint x="215" y="120" />
+        <di:waypoint x="270" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f3rst9_di" bpmnElement="Flow_1f3rst9">
+        <di:waypoint x="370" y="120" />
+        <di:waypoint x="432" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fnpvsc_di" bpmnElement="Activity_0cyfv6p">
+        <dc:Bounds x="270" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02xj7ay_di" bpmnElement="Event_02xj7ay">
+        <dc:Bounds x="432" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Did some refactoring on the IT tests, like introducing new separate methods for awaiting pod readiness etc.

Furthermore enhanced the IT test such that we cover more services. 

What the IT now contains:

 * Deploy a workflow
 * Create a process instance
 * Await elastic readiness
 * [Use a http client to login on operate and request the process definition](https://camunda.slack.com/archives/C9B5270DA/p1646216140017879)
 * Verify the result

We use the retry functionality to make sure to reduce the chance for flakiness, it is similar to our awaitility usage in zeebe test code. 

Next step would be to also introduce the tasklist query api.

related to #214 