### PR TITLE
Added ability to Provide Custome Service Annotations for zeebe-gateway

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -167,6 +167,7 @@ Information about the Zeebe Gateway you can find [here](https://docs.camunda.io/
 | | `service.httpName` | Defines the name of the HTTP endpoint, where for example metrics are provided | `http` |
 | | `service.gatewayPort` | Defines the port of the gateway endpoint, where client commands (gRPC) are sent to | `26500` |
 | | `service.gatewayName` | Defines the name of the gateway endpoint, where client commands (gRPC) are sent to | `gateway` |
+| | `service.annotations` | Defines annotations for the zeebe gateway service | `{ }` | 
 | | `service.internalPort` | Defines the port of the Internal API endpoint, which is used for internal communication | `26502` |
 | | `service.internalName` | Defines the name of the Internal API endpoint, which is used for internal communication | `internal` |
 | | `serviceAccount` | Configuration for the service account where the gateway pods are assigned to | |

--- a/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-service.yaml
+++ b/charts/ccsm-helm/charts/zeebe-gateway/templates/gateway-service.yaml
@@ -4,7 +4,12 @@ metadata:
   name: {{ include "zeebe.names.gateway" . }}
   labels: {{- include "zeebe.labels.gateway" . | nindent 4 }}
   annotations:
+    {{- if .Values.global.annotations}}
     {{- toYaml  .Values.global.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations}}
+    {{ .Values.service.annotations | toYaml | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   selector:

--- a/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
+++ b/charts/ccsm-helm/test/zeebe-gateway/golden/gateway-service.golden.yaml
@@ -13,7 +13,6 @@ metadata:
     app.kubernetes.io/part-of: camunda-cloud-self-managed
     app.kubernetes.io/component: zeebe-gateway
   annotations:
-    {}
 spec:
   type: ClusterIP
   selector:

--- a/charts/ccsm-helm/test/zeebe-gateway/service_test.go
+++ b/charts/ccsm-helm/test/zeebe-gateway/service_test.go
@@ -66,3 +66,21 @@ func (s *serviceTest) TestContainerSetGlobalAnnotations() {
 	// then
 	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
 }
+
+func (s *serviceTest) TestContainerServiceAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"zeebe-gateway.service.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+}

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -266,6 +266,8 @@ zeebe-gateway:
     internalPort: 26502
     # Service.internalName defines the name of the internal api endpoint, which is used for internal communication
     internalName: "internal"
+    # Service.annotations can be used to define annotations, which will be applied to the zeebe-gateway service
+    annotations: {}
 
   # ServiceAccount configuration for the service account where the gateway pods are assigned to
   serviceAccount:


### PR DESCRIPTION
**What?**
I have added the ability for zeebe-gateway service to have its own custom annotations.

**Why?**
Having ONLY common annotations is not enough. For example if we want to expose each service with a custom domain name