### PR TITLE
feat: Added missing annotations for zeebe operate service

### DIFF
--- a/charts/ccsm-helm/README.md
+++ b/charts/ccsm-helm/README.md
@@ -190,6 +190,7 @@ Information about Operate you can find [here](https://docs.camunda.io/docs/compo
 | | `service` | Configuration to configure the Operate service. | |
 | | `service.type` | Defines the [type of the service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) | `ClusterIP` |
 | | `service.port` | Defines the port of the service, where the Operate web application will be available | `80` |
+| | `service.annotations` | Defines annotations for the operate service | `{ }` | 
 | | `resources` | Configuration to set [request and limit configuration for the container](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits) | `requests:`<br>`  cpu: 600m`<br> `  memory: 400Mi`<br>`limits:`<br> ` cpu: 2000m`<br> ` memory: 2Gi` |
 | | `env` | Can be used to set extra environment variables in each operate container | `[ ]` |
 | | `command` | Can be used to [override the default command provided by the container image](https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/) | `[]` |

--- a/charts/ccsm-helm/charts/operate/templates/service.yaml
+++ b/charts/ccsm-helm/charts/operate/templates/service.yaml
@@ -3,6 +3,13 @@ kind: Service
 metadata:
   name: {{ include "operate.fullname" . }}
   labels: {{- include "operate.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.global.annotations}}
+    {{- toYaml .Values.global.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.service.annotations}}
+    {{- toYaml .Values.service.annotations | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/ccsm-helm/test/operate/golden/service.golden.yaml
+++ b/charts/ccsm-helm/test/operate/golden/service.golden.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/version: "1.3.4"
     app.kubernetes.io/part-of: camunda-cloud-self-managed
     app.kubernetes.io/component: operate
+  annotations:
 spec:
   type: ClusterIP
   ports:

--- a/charts/ccsm-helm/test/operate/service_test.go
+++ b/charts/ccsm-helm/test/operate/service_test.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Camunda Services GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operate
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/gruntwork-io/terratest/modules/k8s"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	coreV1 "k8s.io/api/core/v1"
+)
+
+type serviceTest struct {
+	suite.Suite
+	chartPath string
+	release   string
+	namespace string
+	templates []string
+}
+
+func TestServiceTemplate(t *testing.T) {
+	t.Parallel()
+
+	chartPath, err := filepath.Abs("../../")
+	require.NoError(t, err)
+
+	suite.Run(t, &serviceTest{
+		chartPath: chartPath,
+		release:   "ccsm-helm-test",
+		namespace: "ccsm-helm-" + strings.ToLower(random.UniqueId()),
+		templates: []string{"charts/operate/templates/service.yaml"},
+	})
+}
+
+func (s *serviceTest) TestContainerSetGlobalAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+}
+
+func (s *serviceTest) TestContainerServiceAnnotations() {
+	// given
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"operate.service.annotations.foo": "bar",
+		},
+		KubectlOptions: k8s.NewKubectlOptions("", "", s.namespace),
+	}
+
+	// when
+	output := helm.RenderTemplate(s.T(), options, s.chartPath, s.release, s.templates)
+	var service coreV1.Service
+	helm.UnmarshalK8SYaml(s.T(), output, &service)
+
+	// then
+	s.Require().Equal("bar", service.ObjectMeta.Annotations["foo"])
+}

--- a/charts/ccsm-helm/values.yaml
+++ b/charts/ccsm-helm/values.yaml
@@ -303,6 +303,8 @@ operate:
     type: ClusterIP
     # Service.port defines the port of the service, where the operate web application will be available
     port: 80
+    # Service.annotations can be used to define annotations, which will be applied to the operate service
+    annotations: {}
 
   # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
   resources:


### PR DESCRIPTION
**What?**
I have added the ability for operate service to have its own custom annotations.

**Why?**
Having ONLY common annotations is not enough. For example if we want to expose each service with a custom domain name