### PR TITLE
Add Condition for IT gha

### DIFF
--- a/.github/workflows/go-it.yaml
+++ b/.github/workflows/go-it.yaml
@@ -12,7 +12,19 @@ env:
   KUBECTX: 'gke_zeebe-io_europe-west1-b_zeebe-cluster'
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    outputs:
+      secretDefined: ${{ steps.check-secret.outputs.defined }}
+    steps:
+      - id: check-secret
+        env:
+          SECRET: ${{ secrets.K8_SERVER }}
+        if: "${{ env.SECRET != '' }}"
+        run: echo "::set-output name=defined::true"      
   build:
+    needs: [check-secret]
+    if: needs.check-secret.outputs.secretDefined == 'true'
     runs-on: ubuntu-latest
     env:
       KUBECONFIG: .github/config/kubeconfig


### PR DESCRIPTION
Adds a condition to the integration tests github action. This should avoid executing the IT for external contributors.

First I wanted to check just the existence of a secret but this is not possible in conditions, see https://github.com/actions/runner/issues/520

But there is a workaround, which is posted here https://github.com/actions/runner/issues/520#issuecomment-907770967

We could also check the github actor like it is done for dependabot, but this would mean that we have to know who is allowed to run the IT tests. https://github.community/t/how-to-stop-github-actions-workflow-to-trigger-when-the-pull-request-is-from-dependabot-preview/116486 This is the reason why I went the way of checking whether the secret exists.

closes https://github.com/camunda/camunda-cloud-helm/issues/237